### PR TITLE
Revert and Update 02-Deploy Azure Container Instances.md

### DIFF
--- a/Instructions/Walkthroughs/02-Deploy Azure Container Instances.md
+++ b/Instructions/Walkthroughs/02-Deploy Azure Container Instances.md
@@ -24,9 +24,11 @@ In this task, we will create a new container instance for the web application.
 	| Resource group | **myRGContainer** (create new) |
 	| Container name| **mycontainer**|
 	| Region | **(US) East US** |
-	| Image Source| **Quickstart images**|
+	| Image source| **Docker Hub or other registry**|
+	| Image type| **Public**|
 	| Image| **microsoft/aci-helloworld**|
-	| OS Type| **Linux** |
+	| OS type| **Linux** |
+	| Size| ***Leave at the default***|
 	|||
 
 


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 02

Fixes #38  .

Changes proposed in this pull request:

-Reverted back to using **Docker Hub** as source of image and 
-added the **Size** setting.
-corrected capitalization

If we change to using **Quickstart images**, then we need to ***delete*** the **OS type** setting; but I would argue that having the student pull an image from a public registry is a better, ***"real-world"*** example.