### PR TITLE
update 04,06,07,08,16 for details out-of-sync with Azure portal

### DIFF
--- a/Instructions/Walkthroughs/04-Create a virtual network.md
+++ b/Instructions/Walkthroughs/04-Create a virtual network.md
@@ -61,7 +61,7 @@ In this task, we will create two virtual machines in the virtual network.
 
     | Setting | Value |
     | --- | --- |
-    | Resource group | **myRGVNet** |
+    | Resource group | **select default in dropdown (same as Task1-3 & Task2-2)** |
     | Virtual machine name |  **vm2** |
     | Virtual network | **vnet1** |
     | Public IP | **vm2-ip** |

--- a/Instructions/Walkthroughs/06-Create a SQL database.md
+++ b/Instructions/Walkthroughs/06-Create a SQL database.md
@@ -25,9 +25,10 @@ In this task, we will create a SQL database based on the AdventureWorksLT sample
     | Database name| **db1** | 
     | Server | Select **Create new** (A new sidebar will open on the right)|
     | Server name | **sqlserverxxxx** (must be unique) | 
+    | Location | **(US) East US** |
+    | Authentication method | **Use SQL authentication** |
     | Server admin login | **sqluser** |
     | Password | **Pa$$w0rd1234** |
-    | Location | **(US) East US** |
     | Click  | **OK** |
 
    ![Screenshot of the Server pane and the New Server pane with fields filled in as per the table and the Review + create and OK buttons highlighted.](../images/0501.png)

--- a/Instructions/Walkthroughs/07-Implement the Azure IoT Hub.md
+++ b/Instructions/Walkthroughs/07-Implement the Azure IoT Hub.md
@@ -42,7 +42,7 @@ In this task, we will add an IoT device to the IoT hub.
 
 	![Screenshot of the deployment in progress and deployment succeeded notifications in Azure portal.](../images/0601.png)
 
-2. To add a new IoT device, scroll down to the **Explorers** section and click **IoT Devices**. Then, click **+ Add, + Create, + New**.
+2. To add a new IoT device, scroll down to the **Device management** section and click **Devices**. Then, click **+ Add Device**.
 
 	![Screenshot of the IoT devices pane, highlighted within the IoT hub navigation blade, in Azure portal. The New button is highlighted to illustrate how to add a new IoT device identity to IoT hub.](../images/0602.png)
 

--- a/Instructions/Walkthroughs/08-Implement Azure Functions.md
+++ b/Instructions/Walkthroughs/08-Implement Azure Functions.md
@@ -73,7 +73,7 @@ In this task, we will use the Webhook + API function to display a message when t
 
     ![Screenshot of a highlighted function URL and an appended example user name in the address bar of a web browser. The hello message and user name are also highlighted to illustrate the output of the function in the main browser window.](../images/0707.png)
 
-10. When you hit enter, your function runs and every invocation is traced. To view the traces, return to the Portal **HttpTrigger1 \| Code + Test** blade and click **Monitor**. **Configure** Application Insights by selecting the function you chose and the region. Select **Create**.
+10. When you hit enter, your function runs and every invocation is traced. To view the traces, return to the Portal **HttpTrigger1 \| Code + Test** blade and click **Monitor**. You can **configure** Application Insights by selecting the timestamp and click **Run query in Application Insights**.
 
     ![Screenshot of a trace information log resulting from running the function inside the function editor in Azure portal.](../images/0709.png) 
 

--- a/Instructions/Walkthroughs/16-Implement resource tagging.md
+++ b/Instructions/Walkthroughs/16-Implement resource tagging.md
@@ -23,7 +23,7 @@ In this task, we will configure the **Require a tag on resources** policy and as
 
    ![Screenshot of Available Definitions pane with Require a tag on resources selected.](../images/1701.png)
    
-6.  On the **Parameters** tab, type in **Company** for the tag name. And **Contoso** for the Value. Click **Review + create**, and then **Create**.
+6.  On the **Parameters** tab, type in **Company** for the tag name. Click **Review + create**, and then **Create**.
 
     ![Screenshot of Assign policy pane with the Tag name filled out.](../images/1702.png)
 


### PR DESCRIPTION
# Module: 04
## Lab/Demo: 04, 06, 07, 08, 16

Fixes #168, #167 and another couple of issues I found during recent OE deliveries.

Changes proposed in this pull request:

**Lab 04:** fix Task2-6: currently resource group name is **falsely left as myRGVNet** -> change to use RG from pull-down (the one created by students themselves as instructed in task1) so vm1/vm2/vnet1 will be in the same RG
**Lab 06**: Fixes #168
**Lab 07**: incorporate fixes from #167
**Lab 08**: fix Task2-10: currently instructions mentions "Configure Application Insights by selecting the function you chose and the region. Select Create." but I cannot find equivalent of this on UI -> change to configure query Application Insights (not quite sure is this the original intention but it is the closest I could find)
Lab 16: fix Task1-6: currently the instructions ask students to fill in **tag value** while the policy being used was changed and **does not contain a value field** anymore during assignment ->  delete the parts about filling in tag value