### PR TITLE
Update 16-Implement resource tagging.md

### DIFF
--- a/Instructions/Walkthroughs/16-Implement resource tagging.md
+++ b/Instructions/Walkthroughs/16-Implement resource tagging.md
@@ -23,7 +23,7 @@ In this task, we will configure the **Require a tag on resources** policy and as
 
    ![Screenshot of Available Definitions pane with Require a tag on resources selected.](../images/1701.png)
    
-6.  On the **Parameters** tab, type in **Company : Contoso ** for the tag key/value pair name. Click **Review + create**, and then **Create**.
+6.  On the **Parameters** tab, type in **Company ** for the tag name. Click **Review + create**, and then **Create**.
 
     ![Screenshot of Assign policy pane with the Tag name filled out.](../images/1702.png)
 


### PR DESCRIPTION
The policy "require a tag on resources" requires only to add a tag name and not the exact value. Therefore, the **contoso** tag value should be removed from the instruction.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-